### PR TITLE
Add a constant to show replyable is installed.

### DIFF
--- a/postmatic.php
+++ b/postmatic.php
@@ -53,6 +53,6 @@ if ( !class_exists( 'Prompt_Root' ) ) {
 		}
 	}
 }
+define( 'REPLYABLE_INSTALLED', true );
 
 Prompt_Core::load();
-


### PR DESCRIPTION
This can be used instead of relying on class_exists checks, which are pretty generic.