### PR TITLE
Freemius additions

### DIFF
--- a/core/core.php
+++ b/core/core.php
@@ -91,7 +91,7 @@ class Prompt_Core {
 		// Stinky, but need to prevent loading freemius while unit testing
 		return function_exists( '_manually_load_plugin' );
 	}
-	
+
 	/**
 	 * Register the WordPress hooks we will respond to.
 	 */
@@ -266,6 +266,13 @@ class Prompt_Core {
 			);
 
 		return self::$settings_page;
+	}
+
+	/**
+	 * @return Prompt_Freemius
+	 */
+	public static function get_freemius() {
+		return self::$freemius;
 	}
 
 	/**

--- a/core/freemius.php
+++ b/core/freemius.php
@@ -106,7 +106,7 @@ class Prompt_Freemius implements Prompt_Interface_License_Status {
 			10,
 			6
 		);
-		
+
 		$this->freemius->add_action(
 			'after_account_connection',
 			array( $this, 'after_account_connection' ),
@@ -210,6 +210,32 @@ class Prompt_Freemius implements Prompt_Interface_License_Status {
 	 */
 	public function is_paying() {
 		return $this->freemius->is_paying();
+	}
+
+	/**
+	 * Determines if a plan is active or not.
+	 *
+	 * @since 2.2.5
+	 *
+	 * @param string $plan Plan to check.
+	 *
+	 * @return bool If plan is active or not.
+	 */
+	public function is_plan( $plan ) {
+		return $this->freemius->is_plan( $plan );
+	}
+
+	/**
+	 * Determines if a plan is on trial or not.
+	 *
+	 * @since 2.2.5
+	 *
+	 * @param string $plan Plan to check.
+	 *
+	 * @return bool If plan is active or not for trial.
+	 */
+	public function is_trial_plan( $plan ) {
+		return $this->freemius->is_trial_plan( $plan );
 	}
 
 	/**


### PR DESCRIPTION
This PR allows a getter for the freemius instance for re-use.

There are also two new methods introduced:
1. ```is_plan```, which determines if a plan is active or not.
2. ```is_trial_plan```, which determines if a trial is active or not.

Here is some example code how I would use it:

```php
/**
 * Alert that Replyable plan is not sufficient.
 *
 * @return bool false if plan is insufficient, true otherwise
 */
public function check_plan() {
	if ( class_exists( 'Prompt_Core' ) ) {
		$freemius = \Prompt_Core::get_freemius();

		// Now check the plan once the trial has expired.
		if ( ( $freemius->is_plan( 'dailydiscourse' ) || $freemius->is_trial_plan( 'dailydiscourse' ) ) || ( $freemius->is_plan( 'highvolume' ) || $freemius->is_trial_plan( 'highvolume' ) ) ) {
			return true;
		} else {
			add_action( 'admin_notices', array( $this, 'alert_replyable_plan_insufficient' ) );
			return false;
		}
	}
	return false;
}
```